### PR TITLE
patch for #1151

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -106,7 +106,8 @@ Url.fromQueryString = function (query) {
 
     if (key.slice(-2) === '[]') {
       key = key.slice(0, -2);
-      result[key] = result[key] || [];
+      if (! result[key] || ! _.isArray(result[key]))
+        result[key] = [];
       result[key].push(value);
     } else {
       result[key] = value;


### PR DESCRIPTION
This will overwrite the string value with the array that follows it. e.g:

http://example.com/?foo=bar&foo[]=baz becomes `{ foo: ["baz"] }`